### PR TITLE
Avoid managed space leak

### DIFF
--- a/lib/src/Pulsar.hs
+++ b/lib/src/Pulsar.hs
@@ -45,6 +45,7 @@ module Pulsar
   , Consumer(..)
   , Producer(..)
   , Pulsar
+  , PulsarConnection
   , PulsarCtx
   , ConnectData
   , LogLevel(..)

--- a/lib/src/Pulsar/Internal/Core.hs
+++ b/lib/src/Pulsar/Internal/Core.hs
@@ -1,33 +1,60 @@
-{-# LANGUAGE RankNTypes, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-{- Defines a Pulsar Monad, which wraps a Managed resource -}
+{- Defines a Pulsar Monad, which wraps a ReaderT and runs internal computations in the background -}
 module Pulsar.Internal.Core where
 
+import           Control.Concurrent             ( forkIO
+                                                , killThread
+                                                , threadDelay
+                                                )
+import           Control.Concurrent.MVar
 import qualified Control.Logging               as L
-import           Control.Monad.Catch
+import           Control.Monad.Catch            ( MonadThrow
+                                                , throwM
+                                                )
 import           Control.Monad.Managed
+import           Control.Monad.Reader
+import           Data.IORef                     ( readIORef )
+import           Pulsar.Connection              ( AppState(..)
+                                                , PulsarCtx(..)
+                                                )
 
-{- | The main Pulsar monad, which abstracts over a 'Managed' monad. -}
-newtype Pulsar a = Pulsar (Managed a)
+{- | Pulsar connection monad, which abstracts over a 'Managed' monad. -}
+newtype Connection a = Connection (Managed a)
   deriving (Functor, Applicative, Monad, MonadIO, MonadManaged)
 
+instance MonadThrow Connection where
+  throwM = liftIO . throwM
+
+{- | Alias for Connection PulsarCtx. -}
+type PulsarConnection = Connection PulsarCtx
+
+{- | The main Pulsar monad, which abstracts over a 'ReaderT' monad. -}
+newtype Pulsar a = Pulsar (ReaderT PulsarCtx IO a)
+  deriving (Functor, Applicative, Monad, MonadIO, MonadReader PulsarCtx)
+
 {- | Runs a Pulsar computation with default logging to standard output -}
-runPulsar :: forall a b . Pulsar a -> (a -> IO b) -> IO b
-runPulsar (Pulsar mgd) f = do
-  L.setLogTimeFormat "%H:%M:%S%Q"
-  L.withStdoutLogging $ with mgd f
+runPulsar :: PulsarConnection -> Pulsar a -> IO ()
+runPulsar = runPulsar' (LogOptions Debug StdOut)
 
 {- | Runs a Pulsar computation with the supplied logging options -}
-runPulsar' :: forall a b . LogOptions -> Pulsar a -> (a -> IO b) -> IO b
-runPulsar' (LogOptions lvl out) (Pulsar mgd) f = do
-  L.setLogLevel $ convertLogLevel lvl
+runPulsar' :: LogOptions -> PulsarConnection -> Pulsar a -> IO ()
+runPulsar' (LogOptions lvl out) (Connection mgd) (Pulsar mr) = do
+  L.setLogLevel $ fromLogLevel lvl
   L.setLogTimeFormat "%H:%M:%S%Q"
   case out of
-    StdOut  -> L.withStdoutLogging $ with mgd f
-    File fp -> L.withFileLogging fp $ with mgd f
-
-instance MonadThrow Pulsar where
-  throwM = liftIO . throwM
+    StdOut  -> L.withStdoutLogging run
+    File fp -> L.withFileLogging fp run
+ where
+  run = runManaged $ do
+    ctx <- mgd
+    ctxHandler ctx
+    var <- liftIO newEmptyMVar
+    tid <- liftIO . forkIO . void $ runReaderT mr ctx >> putMVar var ()
+    liftIO $ threadDelay (1 * 500000) -- FIXME: find a better way to wait for handlers
+    app <- liftIO $ readIORef (ctxState ctx)
+    sequence_ (appWorkers app)
+    liftIO $ readMVar var >> killThread tid
 
 {- | Internal logging options. Can be used together with `runPulsar'`. -}
 data LogOptions = LogOptions
@@ -41,8 +68,8 @@ data LogLevel = Error | Warn | Info | Debug deriving Show
 {- | Internal logging output, part of 'LogOptions'. Can be used together with `runPulsar'`. -}
 data LogOutput = StdOut | File FilePath deriving Show
 
-convertLogLevel :: LogLevel -> L.LogLevel
-convertLogLevel Error = L.LevelError
-convertLogLevel Warn  = L.LevelWarn
-convertLogLevel Info  = L.LevelInfo
-convertLogLevel Debug = L.LevelDebug
+fromLogLevel :: LogLevel -> L.LogLevel
+fromLogLevel Error = L.LevelError
+fromLogLevel Warn  = L.LevelWarn
+fromLogLevel Info  = L.LevelInfo
+fromLogLevel Debug = L.LevelDebug

--- a/lib/src/Pulsar/Internal/TCPClient.hs
+++ b/lib/src/Pulsar/Internal/TCPClient.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase, OverloadedStrings #-}
+{-# LANGUAGE LambdaCase, OverloadedStrings, RankNTypes #-}
 
 {- A simple TCP client, used to communicate with the Pulsar server -}
 module Pulsar.Internal.TCPClient
@@ -6,26 +6,31 @@ module Pulsar.Internal.TCPClient
   )
 where
 
-import qualified Control.Exception             as E
-import           Control.Monad.IO.Class
-import           Control.Monad.Managed
+import           Control.Monad.Catch            ( bracket
+                                                , bracketOnError
+                                                )
+import           Control.Monad.IO.Class         ( MonadIO
+                                                , liftIO
+                                                )
+import           Control.Monad.Managed          ( MonadManaged
+                                                , managed
+                                                , using
+                                                )
 import qualified Network.Socket                as NS
 
 acquireSocket
   :: (MonadIO m, MonadManaged m) => NS.HostName -> NS.ServiceName -> m NS.Socket
 acquireSocket host port = do
   addr <- liftIO resolve
-  using $ managed
-    (E.bracket
-      (putStrLn "[ Establishing connection with Pulsar ]" >> open addr)
-      (\s -> putStrLn "[ Closing Pulsar connection ]" >> NS.close s)
-    )
+  using $ managed (bracket (acquire addr) release)
  where
+  acquire = (putStrLn "[ Establishing connection with Pulsar ]" >>) . open
+  release = (putStrLn "[ Closing Pulsar connection ]" >>) . NS.close
   resolve = do
     let hints = NS.defaultHints { NS.addrSocketType = NS.Stream }
     NS.getAddrInfo (Just hints) (Just host) (Just port) >>= \case
       [addr] -> pure addr
-      _      -> E.ioError $ userError "Could not resolve socket address"
-  open addr = E.bracketOnError (NS.openSocket addr) NS.close $ \sock -> do
+      _      -> ioError $ userError "Could not resolve socket address"
+  open addr = bracketOnError (NS.openSocket addr) NS.close $ \sock -> do
     NS.connect sock $ NS.addrAddress addr
     return sock

--- a/lib/src/Pulsar/Producer.hs
+++ b/lib/src/Pulsar/Producer.hs
@@ -1,18 +1,26 @@
+{-# LANGUAGE FlexibleContexts #-}
+
 {- Defines a high-level Pulsar producer for the end user -}
 module Pulsar.Producer where
 
-import qualified Control.Monad.Catch           as E
-import           Control.Monad.Managed
+import           Control.Concurrent.Chan
+import           Control.Monad.Catch            ( bracket_ )
+import           Control.Monad.IO.Class         ( MonadIO
+                                                , liftIO
+                                                )
+import           Control.Monad.Managed          ( managed_ )
+import           Control.Monad.Reader           ( MonadReader
+                                                , ask
+                                                )
 import           Data.IORef
 import           Data.Text                      ( Text )
 import qualified Pulsar.Core                   as C
 import           Pulsar.Connection
 import           Pulsar.Types
-import           UnliftIO.Chan
 
 {- | An abstract 'Producer' able to 'produce' messages of type 'PulsarMessage'. -}
 newtype Producer m = Producer
-  { produce :: PulsarMessage -> m () -- ^ Produces a single message.
+  { send :: PulsarMessage -> m () -- ^ Produces a single message.
   }
 
 data ProducerState = ProducerState
@@ -27,23 +35,24 @@ mkSeqId ref = liftIO $ atomicModifyIORef
 
 {- | Create a new 'Producer' by supplying a 'PulsarCtx' (returned by 'Pulsar.connect') and a 'Topic'. -}
 newProducer
-  :: (MonadManaged m, MonadIO f) => PulsarCtx -> Topic -> m (Producer f)
-newProducer (Ctx conn app) topic = do
-  chan  <- newChan
-  pid   <- mkProducerId chan app
-  pname <- liftIO $ mkProducer chan pid
-  pst   <- liftIO $ newIORef (ProducerState 0 pname)
-  using $ managed
-    (E.bracket (pure $ Producer (dispatch chan pid pst))
-               (const $ newReq >>= \r -> C.closeProducer conn chan r pid)
-    )
+  :: (MonadIO m, MonadReader PulsarCtx m, MonadIO f) => Topic -> m (Producer f)
+newProducer topic = do
+  (Ctx conn app _) <- ask
+  chan             <- liftIO newChan
+  pid              <- mkProducerId chan app
+  pname            <- liftIO $ mkProducer conn chan pid app
+  pst              <- liftIO $ newIORef (ProducerState 0 pname)
+  let release = newReq app >>= C.closeProducer conn chan pid
+      handler = managed_ $ bracket_ (pure ()) release
+  addWorker app handler
+  return $ Producer (dispatch conn chan pid pst)
  where
-  newReq = mkRequestId app
-  dispatch chan pid pst msg = do
+  newReq app = mkRequestId app
+  dispatch conn chan pid pst msg = do
     sid <- mkSeqId pst
     liftIO $ C.send conn chan pid sid msg
-  mkProducer chan pid = do
-    req1 <- newReq
+  mkProducer conn chan pid app = do
+    req1 <- newReq app
     C.lookup conn chan req1 topic
-    req2 <- newReq
+    req2 <- newReq app
     C.newProducer conn chan req2 pid topic

--- a/lib/supernova.cabal
+++ b/lib/supernova.cabal
@@ -33,7 +33,8 @@ library
                      , Pulsar.Protocol.Frame
                      , Pulsar.Types
   autogen-modules:     Paths_supernova
-  build-depends:       base                  >= 4.13.0 && < 4.14,
+  build-depends:       async                 >= 2.2.2 && < 2.3,
+                       base                  >= 4.13.0 && < 4.14,
                        bifunctor             >= 0.1.0 && < 0.2,
                        binary                >= 0.8.7 && < 0.9,
                        bytestring            >= 0.10.10 && < 0.11,
@@ -41,12 +42,12 @@ library
                        exceptions            >= 0.10.4 && < 0.11,
                        lens-family-core      >= 2.0.0 && < 2.1,
                        logging               >= 3.0.5 && < 3.1,
+                       mtl                   >= 2.2.2 && < 2.3,
                        text                  >= 1.2.4 && < 1.3,
                        managed               >= 1.0.7 && < 1.1,
                        network               >= 3.1.2 && < 3.2,
                        proto-lens            >= 0.7.0 && < 0.8,
                        proto-lens-runtime    >= 0.7.0 && < 0.8,
-                       unliftio              >= 0.2.13 && < 0.3
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall


### PR DESCRIPTION
closes #4 

Big refactor to avoid running long-lived computations in the `Managed` monad, to avoid space leaks.

- The `Pulsar` monad now wraps a `ReaderT PulsarCtx IO a`.
- A new `Connection` monad that wraps `Managed a` was introduced.
- Removed the `unliftio` dependency.

They are both combined when calling `runPulsar` or `runPulsar'`.