### PR TITLE
Fix SIGTERM for consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ conn = connect defaultConnectData
 program :: Consumer IO -> Producer IO -> IO ()
 program Consumer {..} Producer {..} =
   let c = forever $ fetch >>= \(Message i m) -> msgDecoder m >> ack i
-      p = forever $ traverse_ send messages >> sleep 5
+      p = forever $ sleep 5 >> traverse_ send messages
   in  concurrently_ c p
 ```
 
 A `Message` contains a `MessageID` you need for `ack`ing and a payload defined as a lazy `ByteString`.
+
+> Note that we wait a few seconds before publishing a message to make sure the consumer is already subscribed. Otherwise, it might miss some messages.
 
 Run it with the following command:
 
@@ -55,7 +57,7 @@ import qualified Streamly.Prelude              as S
 program :: Consumer IO -> Producer IO -> IO ()
 program Consumer {..} Producer {..} =
   let c = forever $ fetch >>= \(Message i m) -> msgDecoder m >> ack i
-      p = forever $ traverse_ send messages >> sleep 5
+      p = forever $ sleep 5 >> traverse_ send messages
   in  S.drain . asyncly . maxThreads 10 $ S.yieldM c <> S.yieldM p
 ```
 

--- a/lib/src/Pulsar.hs
+++ b/lib/src/Pulsar.hs
@@ -39,9 +39,11 @@ And the main user program that consume and produce messages concurrently, runnin
 program :: Consumer IO -> Producer IO -> IO ()
 program Consumer {..} Producer {..} =
   let c = forever $ fetch >>= \(Message i m) -> print m >> ack i
-      p = forever $ send "Hello World!" >> threadDelay (5 * 1000000)
+      p = forever $ threadDelay (5 * 1000000) >> send "Hello World!"
   in  concurrently_ c p
 @
+
+We have a delay of 5 seconds before publishing to make sure the consumer is already running. Otherwise, it might miss some messages.
 
 Finally, we put it all together and call 'runPulsar' with the connection and the program in the 'Pulsar' monad.
 

--- a/lib/src/Pulsar/Consumer.hs
+++ b/lib/src/Pulsar/Consumer.hs
@@ -49,7 +49,7 @@ newConsumer topic sub = do
   fchan            <- liftIO newChan
   var              <- liftIO newEmptyMVar
   let acquire = mkSubscriber conn chan cid app >> forkIO (fetcher chan fchan)
-      release = (newReq app >>= C.closeConsumer conn chan cid >>) . killThread
+      release i = killThread i >> newReq app >>= C.closeConsumer conn chan cid
       handler = managed (bracket acquire release) >> liftIO (readMVar var)
   worker <- liftIO $ async (runManaged $ void handler)
   addWorker app (worker, var)

--- a/lib/test/Main.hs
+++ b/lib/test/Main.hs
@@ -53,7 +53,7 @@ pulsar = do
 program :: Consumer IO -> Producer IO -> IO ()
 program Consumer {..} Producer {..} =
   let c = forever $ fetch >>= \(Message i m) -> msgDecoder m >> ack i
-      p = forever $ traverse_ send messages >> sleep 5
+      p = forever $ sleep 5 >> traverse_ send messages
   in  concurrently_ c p
 
 sleep :: Int -> IO ()
@@ -71,5 +71,5 @@ streamDemo = runPulsar' logOpts conn $ do
 streamProgram :: Consumer IO -> Producer IO -> IO ()
 streamProgram (Consumer fetch ack) (Producer send) =
   let c = forever $ fetch >>= \(Message i m) -> msgDecoder m >> ack i
-      p = forever $ traverse_ send messages >> sleep 5
+      p = forever $ sleep 5 >> traverse_ send messages
   in  S.drain . asyncly . maxThreads 10 $ S.yieldM c <> S.yieldM p


### PR DESCRIPTION
The issue was the we were killing the thread after sending the `CloseConsumer` command, which was expecting the response on the same channel that we consume for `fetcher`. By killing the fetcher thread first, we make sure the channel is only read by the response of the `CloseConsumer` command. 