### PR TITLE
(Under-documented) Optional frame fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .ghc.*
 .direnv
 result
+lib/DEBUG.md

--- a/lib/src/Pulsar/Protocol/Encoder.hs
+++ b/lib/src/Pulsar/Protocol/Encoder.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 {- An encoder that understands the Pulsar protocol, as specified at: http://pulsar.apache.org/docs/en/develop-binary-protocol -}
 module Pulsar.Protocol.Encoder
   ( encodeBaseCommand
@@ -34,13 +32,13 @@ mkPayloadCommand cmd meta (Payload pl) = (simpleCmd, payloadCmd)
   -- payload fields
   metadata    = PL.encodeMessage meta
   metaSize    = fromIntegral . CL.length . CL.fromStrict $ metadata
-  metaSizeBS  = B.runPut . B.putInt32be $ metaSize
-  CheckSum cs = computeCheckSum $ metaSizeBS <> CL.fromStrict metadata <> pl
-  payloadSize = fromIntegral . CL.length $ pl
+  metaSizeBS  = B.runPut $ B.putInt32be metaSize
+  checkSum    = computeCheckSum $ metaSizeBS <> CL.fromStrict metadata <> pl
+  payloadSize = fromIntegral $ CL.length pl
   -- frame: extra 14 bytes = 2 (magic number) + 4 (checksum) + 4 (metadata size) + 4 (command size)
   extraBytes  = fromIntegral (14 + metaSize) + payloadSize
   simpleCmd   = mkSimpleCommand extraBytes cmd
-  payloadCmd  = PayloadCommand { frameCheckSum     = cs
+  payloadCmd  = PayloadCommand { frameCheckSum     = Just checkSum
                                , frameMetadataSize = metaSize
                                , frameMetadata     = CL.fromStrict metadata
                                , framePayload      = pl
@@ -55,17 +53,23 @@ encodeSimpleCmd (SimpleCommand ts cs msg) =
 encodeFrame :: Frame -> CL.ByteString
 encodeFrame (SimpleFrame scmd) = encodeSimpleCmd scmd
 encodeFrame (PayloadFrame scmd (PayloadCommand cs mds md p)) =
-  let simpleCmd   = encodeSimpleCmd scmd
-      metaSizeBS  = B.runPut . B.putInt32be $ mds
-      magicNumber = B.runPut . B.putWord16be $ frameMagicNumber
-      crc32cSum   = B.runPut . B.putWord32be $ cs
-      payloadCmd  = magicNumber <> crc32cSum <> metaSizeBS <> md <> p
+  let simpleCmd  = encodeSimpleCmd scmd
+      metaSizeBS = B.runPut $ B.putInt32be mds
+      payloadCmd = encodeOptionalFields cs <> metaSizeBS <> md <> p
   in  simpleCmd <> payloadCmd
+
+-- If a magic number is present, a CRC32-C checksum of everything that comes after it (4 bytes) should follow
+encodeOptionalFields :: Maybe CheckSum -> CL.ByteString
+encodeOptionalFields (Just (CheckSum cs)) =
+  let magicNumber = B.runPut $ B.putWord16be frameMagicNumber
+      crc32cSum   = B.runPut $ B.putWord32be cs
+  in  magicNumber <> crc32cSum
+encodeOptionalFields Nothing = CL.empty
 
 encodeBaseCommand
   :: Maybe MessageMetadata -> Maybe Payload -> BaseCommand -> CL.ByteString
 encodeBaseCommand (Just meta) p cmd =
-  let pl = fromMaybe (Payload "") p
+  let pl = fromMaybe (Payload CL.empty) p
   in  encodeFrame . uncurry PayloadFrame $ mkPayloadCommand cmd meta pl
 encodeBaseCommand Nothing _ cmd =
   encodeFrame . SimpleFrame . mkSimpleCommand 4 $ cmd

--- a/lib/src/Pulsar/Protocol/Frame.hs
+++ b/lib/src/Pulsar/Protocol/Frame.hs
@@ -7,6 +7,7 @@ import           Data.Int                       ( Int32 )
 import           Proto.PulsarApi                ( BaseCommand
                                                 , MessageMetadata
                                                 )
+import           Pulsar.Protocol.CheckSum       ( CheckSum )
 
 -- The maximum allowable size of a single frame is 5 MB: http://pulsar.apache.org/docs/en/develop-binary-protocol/#framing
 frameMaxSize :: Int
@@ -14,7 +15,7 @@ frameMaxSize = 5 * 1024 * 1024 -- 5mb
 
 -- A 2-byte byte array (0x0e01) identifying the current format
 frameMagicNumber :: B.Word16
-frameMagicNumber  = 0x0e01
+frameMagicNumber = 0x0e01
 
 data Frame = SimpleFrame SimpleCmd | PayloadFrame SimpleCmd PayloadCmd
 
@@ -27,7 +28,7 @@ data SimpleCmd = SimpleCommand
 
 -- Payload command: http://pulsar.apache.org/docs/en/develop-binary-protocol/#payload-commands
 data PayloadCmd = PayloadCommand
-  { frameCheckSum :: B.Word32       -- A CRC32-C checksum of everything that comes after it (4 bytes)
+  { frameCheckSum :: Maybe CheckSum -- A CRC32-C checksum of everything that comes after it (4 bytes) - OPTIONAL
   , frameMetadataSize :: Int32      -- The size of the message metadata (4 bytes)
   , frameMetadata :: CL.ByteString  -- The message metadata stored as a binary protobuf message
   , framePayload :: CL.ByteString   -- Anything left in the frame is considered the payload and can include any sequence of bytes


### PR DESCRIPTION
Yeah! Apparently both the magic number and the checksum are optional: https://github.com/Comcast/pulsar-client-go/blob/master/frame/frame.go#L61