### PR TITLE
Export ConnectData data constructors

### DIFF
--- a/lib/src/Pulsar.hs
+++ b/lib/src/Pulsar.hs
@@ -67,7 +67,7 @@ module Pulsar
   , Producer(..)
   , Pulsar
   , PulsarConnection
-  , ConnectData
+  , ConnectData(..)
   , LogLevel(..)
   , LogOptions(..)
   , LogOutput(..)


### PR DESCRIPTION
This commit fixes Pulsar.hs to re-export the data constructors for
ConnectData. This is necessary in order to connect to non-localhost
hosts on non-default ports.